### PR TITLE
Index plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/angeloashmore/gatsby-node-helpers.git"
   },
   "keywords": [
-    "gatsby"
+    "gatsby",
+    "gatsby-plugin"
   ],
   "author": "Angelo Ashmore",
   "license": "MIT",


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search. 

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310