### PR TITLE
Typescript declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.3.0",
   "description": "Gatsby node helper functions to aid node creation.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "babel src --out-dir dist --ignore *.test.js",
+    "declaration": "tsc",
     "format": "prettier --write 'src/**/*.js' 'README.md'",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build && npm run declaration",
     "test": "jest",
     "test:watch": "npm run test -- --watch",
     "watch": "npm run build -- --watch"
@@ -23,13 +25,17 @@
   "author": "Angelo Ashmore",
   "license": "MIT",
   "devDependencies": {
+    "@types/json-stringify-safe": "^5.0.0",
+    "@types/lodash": "^4.14.146",
+    "@types/node": "^12.12.7",
     "babel-cli": "^6.26.0",
     "babel-plugin-rewire": "^1.1.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "jest": "^21.2.1",
-    "prettier": "^1.8.2"
+    "prettier": "^1.8.2",
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "json-stringify-safe": "^5.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const withDigest = obj =>
 
 /**
  * Returns node helpers for creating new nodes.
- * @param {{sourceId?: string, typePrefix?: string, conflictFieldPrefix?: string}} [options={}]
+ * @param {{sourceId?: string, typePrefix: string, conflictFieldPrefix?: string}} options
  */
 const createNodeHelpers = (options = {}) => {
   if (!isPlainObject(options))

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,10 @@ const digest = str =>
 const withDigest = obj =>
   assoc([`internal`, `contentDigest`], digest(stringify(obj)), obj)
 
-// Returns node helpers for creating new nodes.
+/**
+ * Returns node helpers for creating new nodes.
+ * @param {{sourceId?: string, typePrefix?: string, conflictFieldPrefix?: string}} [options={}]
+ */
 const createNodeHelpers = (options = {}) => {
   if (!isPlainObject(options))
     throw new Error(
@@ -67,11 +70,18 @@ const createNodeHelpers = (options = {}) => {
     conflictFieldPrefix = lowerFirst(typePrefix),
   } = options
 
-  // Generates a node ID from a given type and node ID.
+  /**
+   * Generates a node ID from a given type and node ID.
+   * @param {string} type
+   * @param {string} id
+   */
   const generateNodeId = (type, id) =>
     `${typePrefix}__${upperFirst(camelCase(type))}__${id}`
 
-  // Generates a node type name from a given type.
+  /**
+   * Generates a node type name from a given type.
+   * @param {string} type
+   */
   const generateTypeName = type =>
     upperFirst(camelCase(`${typePrefix} ${type}`))
 
@@ -87,7 +97,12 @@ const createNodeHelpers = (options = {}) => {
     return obj
   }
 
-  // Creates a node factory with a given type and middleware processor.
+  /**
+   * Creates a node factory with a given type and middleware processor.
+   * @param {string} type
+   * @param {(node: Object) => Object | Promise<Object>} [middleware]
+   * @returns {(obj: Object, overrides?: Object) => Object | Promise<Object>}
+   */
   const createNodeFactory = (type, middleware = identity) => (
     obj,
     overrides = {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true,
-    // "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "include": ["src/**/*.js"],
+  "exclude": ["**/*.test.js"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "allowJs": true,
+    // "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This PR enables the generation of a typescript declaration file as requested in #12.

There are multiple ways to write or generate a declaration file for a js lib project. I have decided to try a fairly new approach by using typescript on the present js files. This enables the automatic generation of the declaration file via JSDoc (https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html).

The outcome right now looks like this and is put to `dist/index.d.ts`:
```typescript
export default createNodeHelpers;
declare function createNodeHelpers(options?: {
    sourceId?: string | undefined;
    typePrefix: string;
    conflictFieldPrefix?: string | undefined;
}): {
    createNodeFactory: (type: string, middleware?: ((node: Object) => Object | Promise<Object>) | undefined) => (obj: Object, overrides?: Object | undefined) => Object | Promise<Object>;
    generateNodeId: (type: string, id: string) => string;
    generateTypeName: (type: string) => string;
};
```

The only thing that has to be run before publish is `tsc` (every option is set up in `tsconfig.json`). I have also added a `npm run declaration` and added that to `prepublish`.

Let me know what you think.